### PR TITLE
Fixing AOT compile issues

### DIFF
--- a/app/components/breadcrumbService.ts
+++ b/app/components/breadcrumbService.ts
@@ -53,7 +53,7 @@ export class BreadcrumbService {
      * @returns {*}
      */
     getFriendlyNameForRoute(route: string): string {
-        let name;
+        let name: string;
         let routeEnd = route.substr(route.lastIndexOf('/')+1, route.length);
         
         this.routesFriendlyNames.forEach((value, key, map) => {

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "zone.js": "^0.8.5"
   },
   "peerDependencies" : {
-    "@angular/common": "^2.10.0",
-    "@angular/core": "^2.10.0",
-    "@angular/http": "^2.10.0",
-    "@angular/platform-browser": "^2.10.0",
-    "@angular/platform-browser-dynamic": "^2.10.0",
-    "@angular/router": "^2.10.0"
+    "@angular/common": "^2.0.0",
+    "@angular/core": "^2.0.0",
+    "@angular/http": "^2.0.0",
+    "@angular/platform-browser": "^2.0.0",
+    "@angular/platform-browser-dynamic": "^2.0.0",
+    "@angular/router": "^2.0.0"
   },
   "devDependencies": {
     "@angular/compiler": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,6 @@
   "license": "MIT",
   "main": "bundles/app.module.js",
   "dependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/core": "^4.0.0",
-    "@angular/http": "^4.0.0",
-    "@angular/platform-browser": "^4.0.0",
-    "@angular/platform-browser-dynamic": "^4.0.0",
-    "@angular/router": "^4.0.0",
     "angular2-in-memory-web-api": "0.0.21",
     "bootstrap": "4.0.0-alpha.6",
     "core-js": "2.4.1",
@@ -35,6 +29,14 @@
     "rxjs": "^5.1.1",
     "systemjs": "0.19.27",
     "zone.js": "^0.8.5"
+  },
+  "peerDependencies" : {
+    "@angular/common": "^2.10.0",
+    "@angular/core": "^2.10.0",
+    "@angular/http": "^2.10.0",
+    "@angular/platform-browser": "^2.10.0",
+    "@angular/platform-browser-dynamic": "^2.10.0",
+    "@angular/router": "^2.10.0"
   },
   "devDependencies": {
     "@angular/compiler": "^4.0.0",


### PR DESCRIPTION
Fixing the following warning:

node_modules/ng2-breadcrumb/app/components/breadcrumbService.ts(56,13): error TS7005: Variable 'name' implicitly has an 'any' type.