### PR TITLE
Fixing warning during AOT compile

### DIFF
--- a/app/components/breadcrumbService.ts
+++ b/app/components/breadcrumbService.ts
@@ -53,7 +53,7 @@ export class BreadcrumbService {
      * @returns {*}
      */
     getFriendlyNameForRoute(route: string): string {
-        let name;
+        let name: string;
         let routeEnd = route.substr(route.lastIndexOf('/')+1, route.length);
         
         this.routesFriendlyNames.forEach((value, key, map) => {


### PR DESCRIPTION
Fixing the following warning:

node_modules/ng2-breadcrumb/app/components/breadcrumbService.ts(56,13): error TS7005: Variable 'name' implicitly has an 'any' type.