### PR TITLE
Add typings field

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Gerhard Mostert",
   "license": "MIT",
   "main": "bundles/app.module.js",
+  "typings": "bundles/app.module.d.ts",
   "dependencies": {
     "@angular/common": "^4.0.1",
     "@angular/core": "^4.0.1",


### PR DESCRIPTION
This pull request allows you to simplify code and work with proper TS config.

For now, we have to work with this sort of import even if we have proper "main" field : 
`import {Ng2BreadcrumbModule} from 'ng2-breadcrumb/ng2-breadcrumb';`

With this commit we can use 
`import {Ng2BreadcrumbModule} from 'ng2-breadcrumb';`

Until then, the only way to work with this shortcut was specifying 
` "include": [
     "node_modules/**/*.d.ts"
   ],`
in tsconfig file, or use specific path mapping, which is king of ugly.

EDIT:
By the way, it seems that "bundles" files are not up to date with source "app" files. I cannot push them right now but it would be good to generate them as well with up to date sources.

Thanks