### PR TITLE
Move router subscription to constructor

### DIFF
--- a/app/components/breadcrumb.ts
+++ b/app/components/breadcrumb.ts
@@ -23,28 +23,25 @@ export class BreadcrumbComponent implements OnInit, OnChanges {
     @Input() useBootstrap: boolean = true;
     @Input() prefix:       string  = '';
 
-    public _urls: string[];
+    public _urls: string[] = new Array();
     public _routerSubscription: any;
 
     constructor(
         private router: Router,
         private breadcrumbService: BreadcrumbService
-    ) {}
-
-    ngOnInit(): void {
-        this._urls = new Array();
-
-        if (this.prefix.length > 0) {
-            this._urls.unshift(this.prefix);
-        }
-
-        this._routerSubscription = this.router.events.subscribe((navigationEnd:NavigationEnd) => {
-
-           if (navigationEnd instanceof NavigationEnd) {
+    ) {
+        this._routerSubscription = this.router.events.subscribe((navigationEnd: NavigationEnd) => {
+            if (navigationEnd instanceof NavigationEnd) {
                 this._urls.length = 0; //Fastest way to clear out array
                 this.generateBreadcrumbTrail(navigationEnd.urlAfterRedirects ? navigationEnd.urlAfterRedirects : navigationEnd.url);
             }
         });
+    }
+
+    ngOnInit(): void {
+        if (this.prefix.length > 0) {
+            this._urls.unshift(this.prefix);
+        }
     }
 
     ngOnChanges(changes: any): void {


### PR DESCRIPTION
Hi Gerhard, I created this PR because recently I updated my Angular instance to 4.1 and found an issue when you load the page for first time and Breadcrumb doesn't show because NavigationEnd executes before ngOnInit. Please check it for your own aware and ensure if this changes are correct.

Thanks!