### PR TITLE
Make bootstrap optional on a package level

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "@angular/platform-browser": "^4.0.1",
     "@angular/platform-browser-dynamic": "^4.0.1",
     "@angular/router": "^4.0.1",
-    "bootstrap": "4.0.0-alpha.6",
     "core-js": "2.4.1",
     "reflect-metadata": "^0.1.9",
     "rxjs": "^5.3.0",
     "systemjs": "0.19.27",
     "zone.js": "^0.8.5"
+  },
+  "optionalDependencies": {
+    "bootstrap": "4.0.0-alpha.6"
   },
   "devDependencies": {
     "@angular/compiler": "^4.0.1",


### PR DESCRIPTION
According to the readme "Optionally uses bootstrap.css (v 3.x.x) for styling of some elements (although the component is fully functional without it and there is a flag to turn off the dependency)."

I was however not able to find that flag. 

With my changes it should install without even pulling in the bootstrap package, just by specifying --no-optional on npm install.