### PR TITLE
85 - moves angular dependencies to peerDependencies to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,6 @@
   "main": "bundles/app.module.js",
   "typings": "bundles/app.module.d.ts",
   "dependencies": {
-    "@angular/common": "^4.0.1",
-    "@angular/core": "^4.0.1",
-    "@angular/http": "^4.0.1",
-    "@angular/platform-browser": "^4.0.1",
-    "@angular/platform-browser-dynamic": "^4.0.1",
-    "@angular/router": "^4.0.1",
     "bootstrap": "4.0.0-alpha.6",
     "core-js": "2.4.1",
     "reflect-metadata": "^0.1.9",
@@ -37,6 +31,12 @@
     "zone.js": "^0.8.5"
   },
   "devDependencies": {
+    "@angular/common": "^4.0.1",
+    "@angular/core": "^4.0.1",
+    "@angular/http": "^4.0.1",
+    "@angular/platform-browser": "^4.0.1",
+    "@angular/platform-browser-dynamic": "^4.0.1",
+    "@angular/router": "^4.0.1",
     "@angular/compiler": "^4.0.1",
     "@angular/compiler-cli": "^4.0.1",
     "@angular/platform-server": "^4.0.1",
@@ -47,5 +47,15 @@
     "concurrently": "^3.1.0",
     "lite-server": "^2.2.2",
     "typescript": "^2.2.2"
+  },
+  "peerDependencies": {
+    "@angular/common": ">=2.0.0 <5.0.0",
+    "@angular/core": ">=2.0.0 <5.0.0",
+    "@angular/http": ">=2.0.0 <5.0.0",
+    "@angular/platform-browser": ">=2.0.0 <5.0.0",
+    "@angular/platform-browser-dynamic": ">=2.0.0 <5.0.0",
+    "@angular/router": ">=2.0.0 <5.0.0",
+    "rxjs": ">=5.0.0",
+    "zone.js": ">=0.7.0"
   }
 }


### PR DESCRIPTION
This fixes issue #85 by preventing `@angular` dependencies from being installed within the `node_modules` directory of this library, instead just depending on their presence as peer dependencies. 