### PR TITLE
Fixing issue #100

### DIFF
--- a/app/components/breadcrumb.js
+++ b/app/components/breadcrumb.js
@@ -17,9 +17,9 @@ var BreadcrumbComponent = (function () {
     BreadcrumbComponent.prototype.ngOnInit = function () {
         var _this = this;
         this._urls = new Array();
-        if (this.prefix.length > 0) {
-            this._urls.unshift(this.prefix);
-        }
+
+        this.generateBreadcrumbTrail(this.router.url);
+        
         this._routerSubscription = this.router.events.subscribe(function (navigationEnd) {
             if (navigationEnd instanceof router_1.NavigationEnd) {
                 _this._urls.length = 0; //Fastest way to clear out array

--- a/app/components/breadcrumb.ts
+++ b/app/components/breadcrumb.ts
@@ -34,9 +34,7 @@ export class BreadcrumbComponent implements OnInit, OnChanges {
     ngOnInit(): void {
         this._urls = new Array();
 
-        if (this.prefix.length > 0) {
-            this._urls.unshift(this.prefix);
-        }
+        this.generateBreadcrumbTrail(this.router.url);
 
         this._routerSubscription = this.router.events.subscribe((navigationEnd:NavigationEnd) => {
 


### PR DESCRIPTION
ngOnInit now calls generateBreadcrumbTrail so a browser refresh doesn't lose the breadcrumb trail.